### PR TITLE
Contextでのstate管理

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,9 +7,12 @@ import { HeaderOnly } from "./components/templates/HeaderOnly";
 import { DefaultLayout } from "./components/templates/DefaultLayout";
 import "./styles.css";
 import { Router } from "./router/Router";
+import { UserProvider } from "./providers/UserProvider";
 
 export default function App() {
   return (
-    <Router />
+    <UserProvider>
+      <Router />
+    </UserProvider>
   );
 }

--- a/src/components/molecules/SeachInput.jsx
+++ b/src/components/molecules/SeachInput.jsx
@@ -1,10 +1,11 @@
+import { memo } from "react";
 import styled from "styled-components";
 
 import { PrimaryButton } from "../atoms/button/PrimaryButton"
 import { Input } from "../atoms/input/Input"
 
 // SeachInputというコンポーネントをimportすることで、どこでも検索ボックスが使えるようになる
-export const SearchInput = () => {
+export const SearchInput = memo(() => {
   return (
     <SContainer>
       <Input placeholder="検索条件を入力" />
@@ -13,7 +14,7 @@ export const SearchInput = () => {
       </SButtonWrapper>
     </SContainer>
   );
-};
+});
 
 // divタグ内の要素を横並びにする
 const SContainer = styled.div`

--- a/src/components/molecules/user/UserIconWithName.jsx
+++ b/src/components/molecules/user/UserIconWithName.jsx
@@ -3,12 +3,14 @@ import { useContext } from "react";
 import { UserContext } from "../../../providers/UserProvider";
 
 export const UserIconWithName = (props) => {
-  const { image, name, height, width, isAdmin } = props;
+  const { image, name, height, width } = props;
   // useContextを使って、UserContextを取得する
   // UserContextを取得することで、グローバルに参照できる値を参照できる
   // UserContextは、src/providers/UserProvider.jsxで定義している
-  const context = useContext(UserContext);
-  console.log(context);
+  const { userInfo } = useContext(UserContext);
+  console.log(userInfo);
+  // isAdminがtrueであれば、isAdminをtrueにする。userInfoがnullの場合は、falseにする
+  const isAdmin = userInfo ? userInfo.isAdmin : false;
 
   return (
     <SContainer>

--- a/src/components/molecules/user/UserIconWithName.jsx
+++ b/src/components/molecules/user/UserIconWithName.jsx
@@ -1,8 +1,8 @@
 import styled from "styled-components";
-import { useContext } from "react";
+import { memo, useContext } from "react";
 import { UserContext } from "../../../providers/UserProvider";
 
-export const UserIconWithName = (props) => {
+export const UserIconWithName = memo((props) => {
   const { image, name, height, width } = props;
   // useContextを使って、UserContextを取得する
   // UserContextを取得することで、グローバルに参照できる値を参照できる
@@ -20,7 +20,7 @@ export const UserIconWithName = (props) => {
       {isAdmin && <SEdit>編集</SEdit>}
     </SContainer>
   );
-};
+});
 
 const SContainer = styled.div`
   text-align: center; // 中央寄せ

--- a/src/components/molecules/user/UserIconWithName.jsx
+++ b/src/components/molecules/user/UserIconWithName.jsx
@@ -1,7 +1,14 @@
 import styled from "styled-components";
+import { useContext } from "react";
+import { UserContext } from "../../../providers/UserProvider";
 
 export const UserIconWithName = (props) => {
   const { image, name, height, width, isAdmin } = props;
+  // useContextを使って、UserContextを取得する
+  // UserContextを取得することで、グローバルに参照できる値を参照できる
+  // UserContextは、src/providers/UserProvider.jsxで定義している
+  const context = useContext(UserContext);
+  console.log(context);
 
   return (
     <SContainer>

--- a/src/components/organisms/user/UserCard.jsx
+++ b/src/components/organisms/user/UserCard.jsx
@@ -1,8 +1,9 @@
+import { memo } from "react";
 import styled from "styled-components";
 import { Card } from "../../atoms/card/Card";
 import { UserIconWithName } from "../../molecules/user/UserIconWithName";
 
-export const UserCard = (props) => {
+export const UserCard = memo((props) => {
   const { user } = props;
   return (
     <Card>
@@ -19,7 +20,7 @@ export const UserCard = (props) => {
       </SDL>
     </Card>
   );
-};
+});
 
 const SDL = styled.dl`
   text-align: left;

--- a/src/components/organisms/user/UserCard.jsx
+++ b/src/components/organisms/user/UserCard.jsx
@@ -3,10 +3,10 @@ import { Card } from "../../atoms/card/Card";
 import { UserIconWithName } from "../../molecules/user/UserIconWithName";
 
 export const UserCard = (props) => {
-  const { user, isAdmin } = props;
+  const { user } = props;
   return (
     <Card>
-      <UserIconWithName name={user.name} image={user.image} height={160} width={240} isAdmin={isAdmin} />
+      <UserIconWithName name={user.name} image={user.image} height={160} width={240} />
       <SDL>
         <dt>メール</dt>
         <dd>{user.email}</dd>

--- a/src/components/pages/Top.jsx
+++ b/src/components/pages/Top.jsx
@@ -1,14 +1,25 @@
 import React from "react";
+import { useContext } from "react";
 import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
 
 import { SecondaryButton } from "../atoms/button/SecondaryButton";
+import { UserContext } from "../../providers/UserProvider";
 
 export const Top = () => {
   const navigate = useNavigate();
+  const { setUserInfo } = useContext(UserContext);
 
-  const onClickAdmin = () => navigate("/users", { state: { isAdmin: true } });
-  const onClickGeneral = () => navigate("/users", { state: { isAdmin: false } });
+  const onClickAdmin = () => {
+    // adminユーザーの場合は、isAdminをtrueにする
+    setUserInfo({ isAdmin: true });
+    navigate("/users");
+  };
+  const onClickGeneral = () => {
+    // 一般ユーザーの場合は、isAdminをfalseにする
+    setUserInfo({ isAdmin: false });
+    navigate("/users");
+  };
 
   return (
     <SContainer>

--- a/src/components/pages/Users.jsx
+++ b/src/components/pages/Users.jsx
@@ -23,10 +23,6 @@ const users = [...Array(10).keys()].map(((val) => {
 }));
 
 export const Users = () => {
-  const { state } = useLocation();
-  // stateがあれば、state.isAdminを代入する。なければfalseを代入する
-  const isAdmin = state ? state.isAdmin : false;
-
   return (
     <SContainer>
       <h2>ユーザー一覧</h2>
@@ -34,7 +30,7 @@ export const Users = () => {
       <SUserArea>
         {users.map((user) => {
           return (
-            <UserCard key={user.id} user={user} isAdmin={isAdmin} />
+            <UserCard key={user.id} user={user} />
           );
         })}
       </SUserArea>

--- a/src/components/pages/Users.jsx
+++ b/src/components/pages/Users.jsx
@@ -1,8 +1,11 @@
+import { useContext } from "react";
 import styled from "styled-components";
 import { useLocation } from "react-router-dom";
 
 import { SearchInput } from "../molecules/SeachInput";
 import { UserCard } from "../organisms/user/UserCard";
+import { SecondaryButton } from "../atoms/button/SecondaryButton";
+import { UserContext } from "../../providers/UserProvider";
 
 // ユーザー情報のダミーデータ
 // Array(10)で配列を作り、.keys()でインデックスを取得する
@@ -23,10 +26,18 @@ const users = [...Array(10).keys()].map(((val) => {
 }));
 
 export const Users = () => {
+  // useContext()で、UserContextの値を取得する
+  const { userInfo, setUserInfo } = useContext(UserContext);
+  // setUserInfoで、isAdminの値を切り替える
+  // ただ、このままのコードだと、切り替えボタンを押した際に、関係のないUsersコンポーネントの子コンポーネントまで再レンダリングされてしまう
+  // そこで、各子コンポーネントにmemo()を使って、再レンダリングを防ぐ
+  const onClickSwitch = () => { setUserInfo({ isAdmin: !userInfo.isAdmin }) }
   return (
     <SContainer>
       <h2>ユーザー一覧</h2>
       <SearchInput />
+      <br />
+      <SecondaryButton onClick={onClickSwitch}>切り替え</SecondaryButton>
       <SUserArea>
         {users.map((user) => {
           return (

--- a/src/providers/UserProvider.jsx
+++ b/src/providers/UserProvider.jsx
@@ -1,4 +1,5 @@
 import { createContext } from "react";
+import { useState } from "react";
 
 // 初期化では値は必要ないから空のオブジェクトを渡す
 export const UserContext = createContext({});
@@ -6,12 +7,15 @@ export const UserContext = createContext({});
 export const UserProvider = (props) => {
   // Providerのコンポーネントは、何でも囲めるようにPropsとしてchildrenを受け取るようにする
   const { children } = props;
-  const contextName = "紫宮るな";
+  // 実際には、固定値ではなく、useStateなどでstateを管理することが多い
+  // const contextName = "紫宮るな";
+  // useStateを使って、userInfoを管理する。(初期値はnull)
+  const [userInfo, setUserInfo] = useState(null);
 
   return (
     // グローバルに参照できる値をvalueとして渡す
     // Providerで囲ったコンポーネントは、valueの値を参照できる
-    <UserContext.Provider value={{ contextName }}>
+    <UserContext.Provider value={{ userInfo, setUserInfo }}>
       {children}
     </UserContext.Provider>
   );

--- a/src/providers/UserProvider.jsx
+++ b/src/providers/UserProvider.jsx
@@ -1,0 +1,26 @@
+import { createContext } from "react";
+
+// 初期化では値は必要ないから空のオブジェクトを渡す
+export const UserContext = createContext({});
+
+export const UserProvider = (props) => {
+  // Providerのコンポーネントは、何でも囲めるようにPropsとしてchildrenを受け取るようにする
+  const { children } = props;
+  const contextName = "紫宮るな";
+
+  return (
+    // グローバルに参照できる値をvalueとして渡す
+    // Providerで囲ったコンポーネントは、valueの値を参照できる
+    <UserContext.Provider value={{ contextName }}>
+      {children}
+    </UserContext.Provider>
+  );
+};
+
+// 1. providersフォルダーを作成する
+// 2. providersフォルダーの中にUserProvider.jsx(userに関する情報を扱うprovider)を作成する
+// 3. createContextを用いて、グローバルに参照できる値(UserContext)を作成する
+// 4. UserProvider.jsxの中で、UserContext.Providerを用いて、グローバルに参照できる値をvalueとして渡す
+// 5. UserProvider.jsxの中で、childrenを返却するようにする
+// 6. UserProviderで囲って、グローバルに参照できる値を参照できるようにする
+// 7. useContextを用いて、グローバルに参照できる値を参照できるようにする

--- a/src/providers/UserProvider.jsx
+++ b/src/providers/UserProvider.jsx
@@ -8,8 +8,9 @@ export const UserProvider = (props) => {
   // Providerのコンポーネントは、何でも囲めるようにPropsとしてchildrenを受け取るようにする
   const { children } = props;
   // 実際には、固定値ではなく、useStateなどでstateを管理することが多い
-  // const contextName = "紫宮るな";
+  const contextName = "紫宮るな";
   // useStateを使って、userInfoを管理する。(初期値はnull)
+  // グローバルなstateが更新されると、グローバルなstateを参照しているコンポーネントが再レンダリングされることに注意
   const [userInfo, setUserInfo] = useState(null);
 
   return (


### PR DESCRIPTION
- useContextを使うことでpropsのバケツリレーを回避する(グローバルなstate管理)
- ただ、親コンポーネントが再レンダリングされることによって、すべての子コンポーネントが再レンダリングされる問題がある
- memo()を使って上記の問題を回避する